### PR TITLE
Add support for Ruby 2.0+

### DIFF
--- a/ext/shout_ext.c
+++ b/ext/shout_ext.c
@@ -46,6 +46,10 @@
 #define RSTRING_PTR(str)        RSTRING(str)->ptr
 #endif
 
+#ifdef SafeStringValue
+#define Check_SafeStr           SafeStringValue
+#endif
+
 /*
 ----------------- ShoutError --------------------
  */


### PR DESCRIPTION
This is a simple way to add support for Ruby 2.0+ in ruby-shout while remaining backwards compatible. It has been tested with Ruby 1.9.3-p547, 2.1.4, and 2.2.3.